### PR TITLE
Add hideDayPicker and getDayPicker methods to OverlayComponent

### DIFF
--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -564,6 +564,8 @@ export default class DayPickerInput extends React.Component {
         tabIndex={0} // tabIndex is necessary to catch focus/blur events on Safari
         onFocus={this.handleOverlayFocus}
         onBlur={this.handleOverlayBlur}
+        hideDayPicker={this.hideDayPicker}
+        getDayPicker={this.getDayPicker}
       >
         <DayPicker
           ref={el => (this.daypicker = el)}

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -177,6 +177,10 @@ export default class DayPickerInput extends React.Component {
     this.handleMonthChange = this.handleMonthChange.bind(this);
     this.handleOverlayFocus = this.handleOverlayFocus.bind(this);
     this.handleOverlayBlur = this.handleOverlayBlur.bind(this);
+
+    // Binding so when passed to <Overlay /> it keeps the this context
+    this.hideDayPicker = this.hideDayPicker.bind(this);
+    this.getDayPicker = this.getDayPicker.bind(this);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -548,16 +548,12 @@ export default class DayPickerInput extends React.Component {
     } else if (selectedDays) {
       selectedDay = selectedDays;
     }
-    let onTodayButtonClick;
-    if (dayPickerProps.todayButton) {
-      // Set the current day when clicking the today button
-      onTodayButtonClick = () =>
-        this.updateState(
-          new Date(),
-          formatDate(new Date(), format, dayPickerProps.locale),
-          this.hideAfterDayClick
-        );
-    }
+    const onTodayButtonClick = () =>
+      this.updateState(
+        new Date(),
+        formatDate(new Date(), format, dayPickerProps.locale),
+        this.hideAfterDayClick
+      );
     const Overlay = this.props.overlayComponent;
     return (
       <Overlay

--- a/types/Props.d.ts
+++ b/types/Props.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Modifiers, Modifier, DayModifiers } from './Modifiers';
 import { ClassNames, InputClassNames } from './ClassNames';
 import { LocaleUtils } from './LocaleUtils';
+import DayPicker from './DayPicker';
 import DayPickerInput from './DayPickerInput';
 
 export interface CaptionElementProps {
@@ -12,6 +13,17 @@ export interface CaptionElementProps {
   locale: string;
   months?: string[];
   onClick?: React.MouseEventHandler<HTMLElement>;
+}
+
+export interface OverlayComponentProps {
+  classNames: InputClassNames;
+  month: Date;
+  selectedDay: Date;
+  input: any;
+  onFocus: () => void;
+  onBlur: () => void;
+  hideDayPicker: () => void;
+  getDayPicker: () => React.Ref<DayPicker>;
 }
 
 export interface NavbarElementProps {

--- a/types/Props.d.ts
+++ b/types/Props.d.ts
@@ -16,11 +16,7 @@ export interface CaptionElementProps {
 }
 
 export interface OverlayComponentProps {
-<<<<<<< HEAD
   classNames: InputClassNames;
-=======
-  classNames: ClassNames;
->>>>>>> d97112186903e85aebd167d47ec15449dcaff1ef
   month: Date;
   selectedDay: Date;
   input: any;
@@ -29,13 +25,7 @@ export interface OverlayComponentProps {
   hideDayPicker: () => void;
   getDayPicker: () => React.Ref<DayPicker>;
 }
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-=======
->>>>>>> d9711218 (Add hideDayPicker and getDayPicker methods to OverlayComponent)
-=======
->>>>>>> d97112186903e85aebd167d47ec15449dcaff1ef
 export interface NavbarElementProps {
   className: string;
   classNames: ClassNames;

--- a/types/Props.d.ts
+++ b/types/Props.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Modifiers, Modifier, DayModifiers } from './Modifiers';
 import { ClassNames, InputClassNames } from './ClassNames';
 import { LocaleUtils } from './LocaleUtils';
+import DayPicker from './DayPicker';
 import DayPickerInput from './DayPickerInput';
 
 export interface CaptionElementProps {
@@ -14,6 +15,16 @@ export interface CaptionElementProps {
   onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
+export interface OverlayComponentProps {
+  classNames: ClassNames;
+  month: Date;
+  selectedDay: Date;
+  input: any;
+  onFocus: () => void;
+  onBlur: () => void;
+  hideDayPicker: () => void;
+  getDayPicker: () => React.Ref<DayPicker>;
+}
 export interface NavbarElementProps {
   className: string;
   classNames: ClassNames;

--- a/types/Props.d.ts
+++ b/types/Props.d.ts
@@ -25,7 +25,10 @@ export interface OverlayComponentProps {
   hideDayPicker: () => void;
   getDayPicker: () => React.Ref<DayPicker>;
 }
+<<<<<<< HEAD
 
+=======
+>>>>>>> d9711218 (Add hideDayPicker and getDayPicker methods to OverlayComponent)
 export interface NavbarElementProps {
   className: string;
   classNames: ClassNames;


### PR DESCRIPTION
👋🏽 Thanks for opening a pull request!
Added `hideDayPicker` and `getDayPicker` methods to the OverlayComponent props in order to be able to control the datepicker from the Overlay since it would be needed, because of things like a `Done` button or a `Time Picker`. 
