### PR TITLE
Feature/mp 520 set date from overlay

### DIFF
--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -147,8 +147,8 @@ export class DayPicker extends Component {
     pagedNavigation: false,
     showWeekNumbers: false,
     showWeekDays: true,
-    renderDay: (day) => day.getDate(),
-    renderWeek: (weekNumber) => weekNumber,
+    renderDay: day => day.getDate(),
+    renderWeek: weekNumber => weekNumber,
     weekdayElement: <Weekday />,
     navbarElement: <Navbar classNames={classNames} />,
     captionElement: <Caption classNames={classNames} />,
@@ -158,7 +158,7 @@ export class DayPicker extends Component {
     super(props);
 
     const currentMonth = this.getCurrentMonthFromProps(props);
-    //Binding so when passed to <Navbar /> it keeps the this context
+    // Binding so when passed to <Navbar /> it keeps the this context
     this.showMonth = this.showMonth.bind(this);
     this.state = { currentMonth };
   }
@@ -265,7 +265,7 @@ export class DayPicker extends Component {
     });
   }
 
-  showNextMonth = (callback) => {
+  showNextMonth = callback => {
     if (!this.allowNextMonth()) {
       return;
     }
@@ -276,7 +276,7 @@ export class DayPicker extends Component {
     this.showMonth(nextMonth, callback);
   };
 
-  showPreviousMonth = (callback) => {
+  showPreviousMonth = callback => {
     if (!this.allowPreviousMonth()) {
       return;
     }
@@ -381,7 +381,7 @@ export class DayPicker extends Component {
 
   // Event handlers
 
-  handleKeyDown = (e) => {
+  handleKeyDown = e => {
     e.persist();
 
     switch (e.keyCode) {
@@ -399,14 +399,6 @@ export class DayPicker extends Component {
         } else {
           this.showNextMonth();
         }
-        Helpers.cancelEvent(e);
-        break;
-      case UP:
-        this.showPreviousYear();
-        Helpers.cancelEvent(e);
-        break;
-      case DOWN:
-        this.showNextYear();
         Helpers.cancelEvent(e);
         break;
       default:
@@ -486,7 +478,7 @@ export class DayPicker extends Component {
     }
   }
 
-  handleTodayButtonClick = (e) => {
+  handleTodayButtonClick = e => {
     const today = new Date();
     const month = new Date(today.getFullYear(), today.getMonth());
     this.showMonth(month);
@@ -595,12 +587,12 @@ export class DayPicker extends Component {
       <div
         {...this.props.containerProps}
         className={className}
-        ref={(el) => (this.dayPicker = el)}
+        ref={el => (this.dayPicker = el)}
         lang={this.props.locale}
       >
         <div
           className={this.props.classNames.wrapper}
-          ref={(el) => (this.wrapper = el)}
+          ref={el => (this.wrapper = el)}
           tabIndex={
             this.props.canChangeMonth &&
             typeof this.props.tabIndex !== 'undefined'

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -181,6 +181,7 @@ export default class DayPickerInput extends React.Component {
     // Binding so when passed to <Overlay /> it keeps the this context
     this.hideDayPicker = this.hideDayPicker.bind(this);
     this.getDayPicker = this.getDayPicker.bind(this);
+    this.handleMonthChange = this.handleMonthChange.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -566,6 +567,7 @@ export default class DayPickerInput extends React.Component {
         onBlur={this.handleOverlayBlur}
         hideDayPicker={this.hideDayPicker}
         getDayPicker={this.getDayPicker}
+        setDate={this.handleMonthChange}
       >
         <DayPicker
           ref={el => (this.daypicker = el)}

--- a/src/DayPickerInput.js
+++ b/src/DayPickerInput.js
@@ -558,6 +558,9 @@ export default class DayPickerInput extends React.Component {
     const Overlay = this.props.overlayComponent;
     return (
       <Overlay
+        hideDayPicker={this.hideDayPicker}
+        getDayPicker={this.getDayPicker}
+        setDate={this.handleMonthChange}
         classNames={classNames}
         month={this.state.month}
         selectedDay={selectedDay}
@@ -565,9 +568,6 @@ export default class DayPickerInput extends React.Component {
         tabIndex={0} // tabIndex is necessary to catch focus/blur events on Safari
         onFocus={this.handleOverlayFocus}
         onBlur={this.handleOverlayBlur}
-        hideDayPicker={this.hideDayPicker}
-        getDayPicker={this.getDayPicker}
-        setDate={this.handleMonthChange}
       >
         <DayPicker
           ref={el => (this.daypicker = el)}

--- a/test/daypicker/navigation.js
+++ b/test/daypicker/navigation.js
@@ -178,24 +178,6 @@ describe('DayPicker’s navigation', () => {
     expect(showNextMonth).toHaveBeenCalledTimes(1);
     showNextMonth.mockReset();
   });
-  it('should call `showPreviousYear()` when the UP key is pressed', () => {
-    const wrapper = mount(<DayPicker />);
-    const showPreviousYear = jest.spyOn(wrapper.instance(), 'showPreviousYear');
-    wrapper
-      .find('.DayPicker-wrapper')
-      .simulate('keyDown', { keyCode: keys.UP });
-    expect(showPreviousYear).toHaveBeenCalledTimes(1);
-    showPreviousYear.mockReset();
-  });
-  it('should call `showNextYear()` when the DOWN key is pressed', () => {
-    const wrapper = mount(<DayPicker />);
-    const showNextYear = jest.spyOn(wrapper.instance(), 'showNextYear');
-    wrapper
-      .find('.DayPicker-wrapper')
-      .simulate('keyDown', { keyCode: keys.DOWN });
-    expect(showNextYear).toHaveBeenCalledTimes(1);
-    showNextYear.mockReset();
-  });
   it('should call `focusNextDay()` when the RIGHT key is pressed on a day', () => {
     const wrapper = mount(<DayPicker />);
     const focusNextDay = jest.spyOn(wrapper.instance(), 'focusNextDay');

--- a/types/Props.d.ts
+++ b/types/Props.d.ts
@@ -23,7 +23,8 @@ export interface OverlayComponentProps {
   onFocus: () => void;
   onBlur: () => void;
   hideDayPicker: () => void;
-  getDayPicker: () => React.Ref<DayPicker>;
+  getDayPicker: () => DayPicker;
+  setDate: (d: Date) => void;
 }
 
 export interface NavbarElementProps {
@@ -130,9 +131,9 @@ export interface DayPickerProps {
   onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onMonthChange?: (month: Date) => void;
   onTodayButtonClick?: (
-    day: Date,
-    modifiers: DayModifiers,
-    e: React.MouseEvent<HTMLButtonElement>
+    day?: Date,
+    modifiers?: DayModifiers,
+    e?: React.MouseEvent<HTMLButtonElement>
   ) => void;
   onWeekClick?: (
     weekNumber: number,


### PR DESCRIPTION
👋🏽 Thanks for opening a pull request!
Added a way to set the date from the overlay component and removed key down for arrows up and down listeners for year changing since they were interfering with the current select for year changing!
* Please explain clearly your changes. If they involve a lot of code, let discuss them first in on our chat: https://spectrum.chat/react-day-picker?tab=chat
* 🙏🏽 Please **DO NOT** build files or update the docs in your pull request – as this may cause git conflicts. Thanks!
